### PR TITLE
Fix to pass charset to .any()

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ Multer.prototype.none = function () {
 Multer.prototype.any = function () {
   function setup () {
     return {
+      charset: this.charset,
       limits: this.limits,
       preservePath: this.preservePath,
       storage: this.storage,


### PR DESCRIPTION
Fixed a bug that charset was not set in [.any()](https://github.com/expressjs/multer#any) setup.
